### PR TITLE
[init.vim] replace galaxyline.nvim for a better maintained fork

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -9,7 +9,7 @@ call plug#begin(stdpath('data') . 'vimplug')
     Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
     Plug 'nvim-treesitter/nvim-treesitter-textobjects'
 
-    Plug 'glepnir/galaxyline.nvim', { 'branch': 'main' }
+    Plug 'NTBBloodbath/galaxyline.nvim' "Maintained galaxyline
     Plug 'kyazdani42/nvim-web-devicons'  " needed for galaxyline icons
 
     Plug 'NLKNguyen/papercolor-theme'


### PR DESCRIPTION
glepnir galaxyline is breaking LSP, as per issue below:

https://github.com/glepnir/galaxyline.nvim/issues/223

Replacing it with https://github.com/NTBBloodbath/galaxyline.nvim solves this issue.